### PR TITLE
reset score to zero after claiming

### DIFF
--- a/packages/nextjs/app/game/page.tsx
+++ b/packages/nextjs/app/game/page.tsx
@@ -146,6 +146,7 @@ const Game: React.FC = () => {
           onBlockConfirmation: txnReceipt => {
             localStorage.setItem("lastClaimTimestamp", currentTime.toString());
             console.log("Reward claimed successfully!", txnReceipt);
+            setScore(0);
           },
         },
       );


### PR DESCRIPTION
## Description
This PR includes smack mouch deployment on monad devnet and adds a reward system that give users DMON tokens by the formula FINAL SCORE / TIME SURVIVED.

Fixes #12

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #12_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: 0xFb9BaA70f73A3EBD2350F94B8CFa335d92a1BbB5
